### PR TITLE
Avoid "Symbol's function definition is void: org-babel-get-header"

### DIFF
--- a/ob-mathematica.el
+++ b/ob-mathematica.el
@@ -28,7 +28,9 @@
 
 (defun org-babel-expand-body:mathematica (body params)
   "Expand BODY according to PARAMS, return the expanded body."
-  (let ((vars (mapcar #'cdr (org-babel-get-header params :var))))
+  (let ((vars (if (fboundp 'org-babel-get-header)
+		  (mapcar #'cdr (org-babel-get-header params :var))
+		(org-babel--get-vars params))))
     (concat
      (mapconcat ;; define any variables
       (lambda (pair)


### PR DESCRIPTION
I created a patch to resolve #1.

It seems to be related to the following changes.

<https://orgmode.org/worg/org-release-notes.html>
```
Version 9.0
  Removed functions
    org-babel-get-header is removed.
      Use org-babel--get-vars or assq instead, as applicable.
```
